### PR TITLE
Simplifies and improves exposure control, more testing needed

### DIFF
--- a/src/gsttis_auto_exposure.c
+++ b/src/gsttis_auto_exposure.c
@@ -65,7 +65,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tis_auto_exposure_debug_category);
 
 /* Constants */
 static gdouble K_GAIN     = 3.0;
-static gdouble K_CONTROL  = 4.0 / 255;
+static gdouble K_CONTROL  = 1.3 / 255;
 static gdouble K_DEADBAND = 5.0;
 static gdouble K_ADJUST   = 1.0 / 4;
 static gdouble K_SMALL    = 1e-9;
@@ -235,7 +235,6 @@ static void gst_tis_auto_exposure_init (GstTis_Auto_Exposure *self)
     self->auto_exposure = TRUE;
     self->auto_gain = TRUE;
 
-    self->frame_counter = 0;
     self->camera_src = NULL;
 }
 
@@ -847,7 +846,7 @@ static void correct_brightness (GstTis_Auto_Exposure* self, GstBuffer* buf)
     if (fabs(offset) > K_DEADBAND)
     {
          /* Compute control change from offset */
-         const gdouble change = pow(K_CONTROL * offset, 3);
+         const gdouble change = K_CONTROL * offset;
 
 	 /* Check if too bright */
 	 if (change < 0.0)
@@ -883,12 +882,7 @@ static GstFlowReturn gst_tis_auto_exposure_transform_ip (GstBaseTransform* trans
         return GST_FLOW_OK;
     }
 
-    if (self->frame_counter > 3)
-    {
-        correct_brightness(self, buf);
-        self->frame_counter = 0;
-    }
-    self->frame_counter++;
+    correct_brightness(self, buf);
 
     return GST_FLOW_OK;
 }

--- a/src/gsttis_auto_exposure.c
+++ b/src/gsttis_auto_exposure.c
@@ -64,10 +64,10 @@ GST_DEBUG_CATEGORY_STATIC (gst_tis_auto_exposure_debug_category);
 #define GST_CAT_DEFAULT gst_tis_auto_exposure_debug_category
 
 /* Constants */
-static gdouble K_g = 10.0;
-static gdouble K_e = 10000.0;
-static gdouble K_ge = 1.0;
-static gdouble K_eg = 1000.0;
+static gdouble K_g = 1.0;
+static gdouble K_e = 1000.0;
+static gdouble K_ge = 0.1;
+static gdouble K_eg = 100.0;
 
 /* prototypes */
 

--- a/src/gsttis_auto_exposure.c
+++ b/src/gsttis_auto_exposure.c
@@ -65,7 +65,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tis_auto_exposure_debug_category);
 
 /* Constants */
 static gdouble K_GAIN     = 3.0;
-static gdouble K_CONTROL  = 1.3 / 255;
+static gdouble K_CONTROL  = 0.5 / 255;
 static gdouble K_DEADBAND = 5.0;
 static gdouble K_ADJUST   = 1.0 / 4;
 static gdouble K_SMALL    = 1e-9;

--- a/src/gsttis_auto_exposure.h
+++ b/src/gsttis_auto_exposure.h
@@ -104,8 +104,6 @@ typedef struct GstTis_Auto_Exposure
     gint framerate_numerator;
     gint framerate_denominator;
 
-    gint frame_counter;
-
 } GstTis_Auto_Exposure;
 
 typedef struct GstTis_Auto_ExposureClass


### PR DESCRIPTION
I have had some issues with the auto exposure functionality with the DFM 25GX236-ML board camera. The exposure time seems to be set to 10% of what is the maximal, so it is 4 ms when it could be 40 ms for a framerate of 25 Hz. As a result gain is much higher that it needed be, and I get flickering in the video from the fluorescent light in my office.

Indeed there seems that there is a factor 10 error in a constant when determining the maximal exposure time with aravis. Yet fixing this alone did not solve the problem. I found the code a bit cumbersome to understand, so I spent some hours rewriting the exposure control parts.

The deviation from the reference brightness is now called _offset_ and is a floating point number with value (y - r) / r where _y_ is the measured brightness and _r_ is the reference. It is (normally) in the range -1.0 to 1.0 where positive is too bright and negative is to dark.

If the offset is above a threshold the brightness will be reduced, either by reducing the gain with (K_g \* offset),  or if the gain is at min, reduce the exposure time with (K_e \* offset).

If the offset is below a threshold the brightness will be increased, either by increasing the exposure time with -(K_e \* offset),  or if the exposure time is at max, increase the gain with -(K_g \* offset).

If the offset is withing the acceptable range it will be tried to reduce gain and increase exposure time with K_ge and K_eg respectively.

I done some simple testing of this solution, and it seems quite responsive. The following graph shows the first test, where I turned off lights in the office, covered the camera several times with my hand and jacked, and the turned on the lights in the office again. Here offset is in %, and exposure is in milliseconds for scale.

![camera_test](https://cloud.githubusercontent.com/assets/1246864/15541343/57478a0e-228c-11e6-93d9-298789222ff1.png)

I also tested the adjustment by setting the gain high and exposure time low, and as can be seen it swings in rather fast.

![camera_test2](https://cloud.githubusercontent.com/assets/1246864/15541347/5b64ba62-228c-11e6-82f2-b2a72008e91e.png)

Notice that this code is **not complete and production ready**, it is the results of a few hours of coding and testing. The constants K_e, K_g, K_ge and K_eg needs tuning to specific cameras for instance. I would very much like to have your feedback (pun intended) on it.
