### PR TITLE
DeviceIndex: get_device_list: add timeout while waiting

### DIFF
--- a/src/DeviceIndex.cpp
+++ b/src/DeviceIndex.cpp
@@ -210,6 +210,7 @@ std::vector<DeviceInfo> DeviceIndex::get_device_list () const
     while(!have_list)
     {
         // wait
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
     return device_list;


### PR DESCRIPTION
Add a 500ms timeout while waiting for the device list. This reduces
CPU load dramatically. Furthermore on our custom i.MX6 board sometimes
the detection of the device failed without this patch. In these cases
this wait-for-device-list looped infinitely.

Fixes: 732a0ed092d9 ("Minimize waiting period for first valid device")
Signed-off-by: Richard Leitner <richard.leitner@skidata.com>