### PR TITLE
v4l2_utils: get_v4l2_device_list: don't abort on non-usb video device

### DIFF
--- a/src/v4l2_utils.cpp
+++ b/src/v4l2_utils.cpp
@@ -602,9 +602,10 @@ std::vector<DeviceInfo> tcam::get_v4l2_device_list ()
 
         struct udev_device* parent_device = udev_device_get_parent_with_subsystem_devtype(dev, "usb", "usb_device");
 
+        /* skip this device if we can't get the usb parent */
         if (!parent_device)
         {
-            return device_list;
+            continue;
         }
 
         /* From here, we can call get_sysattr_value() for each file


### PR DESCRIPTION
Let the v4l2 device_list gathering routine skip non-usb video devices
instead of aborting the discovery. This is needed to use "The Imaging
Source" USB cameras with another non-usb video device registered before.

Signed-off-by: Richard Leitner <richard.leitner@skidata.com>