### PR TITLE
uvc/udev: fix uvc extension loading for USB2 cameras

### DIFF
--- a/data/udev/80-theimagingsource-cameras.rules.in
+++ b/data/udev/80-theimagingsource-cameras.rules.in
@@ -69,9 +69,9 @@ ACTION=="add", SUBSYSTEM=="video4linux", \
 # Product IDs 0x82xx, 0x83xx = 22U, 72U
 #
 ACTION=="add", SUBSYSTEM=="video4linux", \
-               ATTRS{idVendor}=="199e", ATTRS{speed}=="82??", \
+               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="82??", \
                RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb2.json"
 
 ACTION=="add", SUBSYSTEM=="video4linux", \
-               ATTRS{idVendor}=="199e", ATTRS{speed}=="83??", \
+               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="83??", \
                RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb2.json"


### PR DESCRIPTION
The udev rules for USB2 cameras compared the first byte of the USB
product ID to the speed attribute. This problem was introduced in commit
2adc718 ("uvc/udev: Fix extension unit handling for USB3 cameras") when
changing from speed comparison to USB product IDs.

This commit fixes that udev rule by checking the correct attribute
against the first byte of the USB product ID.

Fixes: 2adc718 ("uvc/udev: Fix extension unit handling for USB3 cameras")
Signed-off-by: Richard Leitner <richard.leitner@skidata.com>