### PR TITLE
remove volatile from g_once_init_enter input

### DIFF
--- a/src/gstreamer-1.0/gstmetatcamstatistics.cpp
+++ b/src/gstreamer-1.0/gstmetatcamstatistics.cpp
@@ -19,7 +19,7 @@
 
 GType tcam_statistics_meta_api_get_type (void)
 {
-    static volatile GType type;
+    static GType type;
     static const gchar* tags[] = {"id", "val", NULL};
 
     if (g_once_init_enter(&type))


### PR DESCRIPTION
The input to `g_once_init_enter` expands to the second argument of `__atomic_load`.  This throws an error on newer versions of glib if the input is volatile:
```
error: argument 2 of ‘__atomic_load’ must not be a pointer to a ‘volatile’ type
```