### PR TITLE
udev/rules: fix namespace

### DIFF
--- a/libs/dutils_image/src/dutils_img_filter/transform/fcc1x_packed/transform_fcc1x_to_fcc8_ref.cpp
+++ b/libs/dutils_image/src/dutils_img_filter/transform/fcc1x_packed/transform_fcc1x_to_fcc8_ref.cpp
@@ -9,9 +9,9 @@ using filter_params = img_filter::filter_params;
 
 namespace
 {
-inline uint8_t  apply_wb_ref( uint16_t val, float fac ) noexcept {
+inline uint8_t  apply_wb_ref( uint16_t v, float fac ) noexcept {
     assert( fac >= 0.f );
-    const auto val = lroundf( val * fac );
+    const auto val = lroundf( v * fac );
     const auto res = static_cast<unsigned int>( val );
     return (res > 0xFFFF) ? 0xFF : static_cast<uint8_t>(res >> 8);
 }

--- a/src/LibraryHandle.cpp
+++ b/src/LibraryHandle.cpp
@@ -20,8 +20,8 @@
 #include <string>
 
 
-std::shared_ptr<LibraryHandle> tcam::LibraryHandle::open(const std::string& name,
-                                                         const std::string& path)
+std::shared_ptr<tcam::LibraryHandle> tcam::LibraryHandle::open(const std::string& name,
+                                                               const std::string& path)
 {
     // std::shared_ptr<LibraryHandle> lib = std::make_shared<LibraryHandle>(name, path);
     std::shared_ptr<LibraryHandle> lib =


### PR DESCRIPTION
Small cleanup of namespace. Note that tcam::LibraryHandle is used everywhere else in the file except for the updated line.