### PR TITLE
Make NEON an option

### DIFF
--- a/CMakeOptions.cmake
+++ b/CMakeOptions.cmake
@@ -24,6 +24,7 @@ option(TCAM_BUILD_TOOLS    "Build additional utilities"           ON)
 option(TCAM_BUILD_DOCUMENTATION "Build internal code documentation"    ON)
 option(TCAM_BUILD_TESTS    "Build tests."                         OFF)
 option(TCAM_BUILD_VIRTCAM  "Build virtual camera backend" ON)
+option(TCAM_BUILD_USE_ARM_NEON  "Use ARM neon extention" ON)
 
 option(TCAM_INTERNAL_ARAVIS "Use internal aravis dependency instead of system libraries" ON)
 option(TCAM_ARAVIS_USB_VISION "Use aravis usb vision backend. Disables v4l2." ON)
@@ -136,3 +137,9 @@ if (TCAM_BUILD_GIGETOOL_ONLY)
   set(TCAM_ENABLED_MODULES "tcam-gigetool")
 
 endif (TCAM_BUILD_GIGETOOL_ONLY)
+
+if (TCAM_BUILD_USE_ARM_NEON)
+	set(DUTILS_USE_NEON  ON)
+else ()
+	set(DUTILS_USE_NEON  OFF)
+endif (TCAM_BUILD_USE_ARM_NEON)

--- a/libs/dutils_image/src/dutils_img_filter/CMakeLists.txt
+++ b/libs/dutils_image/src/dutils_img_filter/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library( dutils_img_filter_c STATIC
 	"filter/whitebalance/wb_apply_c.cpp"
 	"filter/whitebalance/wb_apply_by16_c.cpp"
 	"filter/whitebalance/wb_apply_by8_c.cpp"
+	"filter/whitebalance/wb_apply_byfloat_c.cpp"
 
 	"transform/mono_to_bgr/transform_mono_to_bgr.h"
 	"transform/mono_to_bgr/transform_mono_to_bgr_internal.h"

--- a/src/gstreamer-1.0/tcamconvert/CMakeLists.txt
+++ b/src/gstreamer-1.0/tcamconvert/CMakeLists.txt
@@ -34,6 +34,11 @@ target_include_directories(tcamconvert
 
 set_project_warnings(tcamconvert)
 
+set(DUTIL_LIBS_OPTI "")
+if(TCAM_BUILD_USE_ARM_NEON)
+	set(DUTIL_LIBS_OPTI "dutils_img::img_filter_optimized")
+endif(TCAM_BUILD_USE_ARM_NEON)
+
 target_link_libraries(tcamconvert
   PRIVATE
   spdlog::spdlog
@@ -43,10 +48,8 @@ target_link_libraries(tcamconvert
   ${GSTREAMER_LIBRARIES}
   ${GSTREAMER_BASE_LIBRARIES}
   ${GSTREAMER_VIDEO_LIBRARIES}
-
   dutils_img::base
-  dutils_img::img_filter_optimized
-
+  ${DUTIL_LIBS_OPTI}
   tcamprop1::consumer
   )
 

--- a/src/gstreamer-1.0/tcamconvert/transform_impl.cpp
+++ b/src/gstreamer-1.0/tcamconvert/transform_impl.cpp
@@ -203,11 +203,11 @@ auto tcamconvert::tcamconvert_get_supported_output_fccs(img::fourcc src_fcc)
 
 static auto find_transform_unary_wb_func(img::img_type type)
 {
-#if defined DUTILS_ARCH_ARM
+#if defined __ARM_NEON__
     auto wb_func = img_filter::whitebalance::get_apply_img_neon(type);
 #elif defined DUTILS_ARCH_SSE41
     auto wb_func = img_filter::whitebalance::get_apply_img_sse41(type);
-#elif
+#else
     auto wb_func = img_filter::whitebalance::get_apply_img_c(type);
 #endif
     return wb_func;
@@ -216,11 +216,11 @@ static auto find_transform_unary_wb_func(img::img_type type)
 
 static auto find_transform_mono_to_bgr_func(img::img_type dst_type, img::img_type src_type)
 {
-#if defined DUTILS_ARCH_ARM
+#if defined __ARM_NEON__
     auto func = img_filter::transform::get_transform_mono_to_bgr_neon(dst_type, src_type);
 #elif defined DUTILS_ARCH_SSE41
     auto func = img_filter::transform::get_transform_mono_to_bgr_sse41(dst_type, src_type);
-#elif
+#else
     auto func = img_filter::transform::get_transform_mono_to_bgr_c(dst_type, src_type);
 #endif
     return func;
@@ -233,12 +233,12 @@ static auto find_transform_function_type(img::img_type dst_type, img::img_type s
         img_filter::transform_function_type (*)(const img::img_type&, const img::img_type&);
 
     static func_type func_list[] = {
-#if defined DUTILS_ARCH_ARM
+#if defined __ARM_NEON__
         img_filter::transform::fcc1x_packed::get_transform_fcc10or12_packed_to_fcc8_neon_v0,
         img_filter::transform::fcc1x_packed::get_transform_fcc10or12_packed_to_fcc16_neon_v0,
         img_filter::transform::get_transform_fcc8_to_fcc16_neon,
         img_filter::transform::get_transform_fcc16_to_fcc8_neon,
-#else
+#elif defined DUTILS_ARCH_SSE41
         img_filter::transform::fcc1x_packed::get_transform_fcc10or12_packed_to_fcc8_ssse3,
         img_filter::transform::fcc1x_packed::get_transform_fcc10or12_packed_to_fcc16_ssse3,
         img_filter::transform::get_transform_fcc8_to_fcc16_sse41,
@@ -269,7 +269,7 @@ static auto find_transform_function_wb_type(img::img_type dst_type, img::img_typ
         img_filter::transform_function_param_type (*)(const img::img_type&, const img::img_type&);
 
     static func_type func_list[] = {
-#if defined DUTILS_ARCH_ARM
+#ifdef __ARM_NEON__
         img_filter::transform::fcc1x_packed::get_transform_fcc1x_to_fcc8_neon_v0,
     //img_filter::transform::fcc1x_packed::get_transform_fcc10or12_packed_to_fcc16_neon_v0,
     //img_filter::transform::get_transform_fcc8_to_fcc16_neon,
@@ -303,11 +303,11 @@ static auto find_transform_function_wb_type(img::img_type dst_type, img::img_typ
 static auto find_bayer8_to_bgra_func(const img::img_type& dst_type, const img::img_type& src_type)
     -> tcamconvert::transform_binary_func
 {
-#if defined DUTILS_ARCH_ARM
+#if defined __ARM_NEON__
     auto func = img_filter::transform::by_edge::get_transform_by8_to_dst_neon(dst_type, src_type);
 #elif defined DUTILS_ARCH_SSE41
     auto func = img_filter::transform::by_edge::get_transform_by8_to_dst_sse41(dst_type, src_type);
-#elif
+#else
     auto func = img_filter::transform::by_edge::get_transform_by8_to_dst_c(dst_type, src_type);
 #endif
     return [func](const img::img_descriptor& dst, const img::img_descriptor& src)


### PR DESCRIPTION
We use a Tegra SOC, that does not have the neon extension. By default, the library uses NEON instructions for some operation if it is built for ARM architecture. This branch adds an option to disable NEON support.

FYI, I am not so well trained with cmake, so if you have some advice to improve this, I am happy to hear them. 
