### PR TITLE
fix 2 linter warnings in gui code

### DIFF
--- a/tools/tcam-capture/mainwindow.cpp
+++ b/tools/tcam-capture/mainwindow.cpp
@@ -47,7 +47,7 @@ namespace
 bool has_property (GstElement* element, const char* name)
 {
     return g_object_class_find_property(G_OBJECT_GET_CLASS(element), name) != nullptr;
-};
+}
 
 } // namespace
 

--- a/tools/tcam-capture/propertywidget.cpp
+++ b/tools/tcam-capture/propertywidget.cpp
@@ -365,6 +365,10 @@ void IntWidget::setup_ui()
         {
             scale = TcamSliderScale::Logarithmic;
         }
+        else
+        {
+            scale = TcamSliderScale::Linear;
+        }
 
         p_slider = new TcamSlider(scale);
     }


### PR DESCRIPTION
Fix more linter warnings with newer compilers:

-  a spurious ;
-  an uninitialized scale variable.

How Has This Been Tested?

Compile on newer systems.

Is this pull request on the correct branch?

rebased to upstream development
in used since may 2025

