### PR TITLE
Filter metadata nodes from TIS V4L2 discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ image_dir.py
 
 .idea/
 build/
+build-debug/
 .vscode/
 nbproject
 .vs/

--- a/data/udev/80-theimagingsource-cameras.rules.in
+++ b/data/udev/80-theimagingsource-cameras.rules.in
@@ -51,19 +51,19 @@ ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="199e", TEST=="power/control", 
 # Product IDs 0x90xx, 0x94xx, 0x98xx, 0x9cxx = 33U, 37U, 38U, 32U
 #
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="90??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb33.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="94??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb37.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="98??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb33.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="9c??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb33.json"
 
@@ -80,15 +80,15 @@ ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="199e", TEST=="power/control", 
 # @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="84??", \
 # @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb23.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="85??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb23.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="86??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb23.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="87??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb23.json"
 
@@ -99,14 +99,14 @@ ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="199e", TEST=="power/control", 
 # Product ID  0x9c87         = 52U
 #
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="82??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb2.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="83??", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb2.json"
 
-@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", \
+@SILENT@ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
 @SILENT@               ATTRS{idVendor}=="199e", ATTRS{idProduct}=="9c87", \
 @SILENT@               RUN+="@TCAM_INSTALL_BIN@/tcam-uvc-extension-loader --device=/dev/%k -f @TCAM_INSTALL_UVC_EXTENSION@/usb2.json"

--- a/doc/pages/tcam-uvc-extension-loader.rst
+++ b/doc/pages/tcam-uvc-extension-loader.rst
@@ -37,6 +37,8 @@ tcam-uvc-extension-loader has the following arguments:
     -d, --device  Device that shall receive the extension unit. (Default: /dev/video0)
     -f, --file    Extension unit file that shall be loaded (This flag is required)
 
+The device node must be a video capture node. Metadata capture nodes are rejected.
+
 Plug & Play
 ===========
 

--- a/doc/pages/udev.rst
+++ b/doc/pages/udev.rst
@@ -41,7 +41,7 @@ These are loaded automatically when the camera is connected to ensure full opera
 
 .. code-block:: sh
 
-   ACTION=="add", SUBSYSTEM=="video4linux", \
+   ACTION=="add", SUBSYSTEM=="video4linux", ATTR{index}=="0", \
                   ATTRS{idVendor}=="199e", ATTRS{idProduct}=="<DEVICE productID>", \
                   RUN+="/install-path-to/tcam-uvc-extension-loader --device=/dev/%k -f /install-path-to-uvc-extension-unit/extension.json"
 

--- a/src/v4l2/uvc-extension-loader-check.h
+++ b/src/v4l2/uvc-extension-loader-check.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <linux/videodev2.h>
+
+namespace tcam::uvc
+{
+
+inline __u32 get_effective_v4l2_caps(const v4l2_capability& caps) noexcept
+{
+    if (caps.capabilities & V4L2_CAP_DEVICE_CAPS)
+    {
+        return caps.device_caps;
+    }
+    return caps.capabilities;
+}
+
+inline bool is_metadata_capture_device(const v4l2_capability& caps) noexcept
+{
+    return (get_effective_v4l2_caps(caps) & V4L2_CAP_META_CAPTURE) != 0;
+}
+
+} // namespace tcam::uvc

--- a/src/v4l2/v4l2_utils.cpp
+++ b/src/v4l2/v4l2_utils.cpp
@@ -75,6 +75,14 @@ std::vector<tcam::DeviceInfo> tcam::get_v4l2_device_list()
         path = udev_list_entry_get_name(dev_list_entry);
         struct udev_device* dev = udev_device_new_from_syspath(udev, path);
 
+        // Skip metadata/sibling nodes and keep the primary capture node only.
+        const char* node_index = udev_device_get_sysattr_value(dev, "index");
+        if (node_index != nullptr && strcmp(node_index, "0") != 0)
+        {
+            udev_device_unref(dev);
+            continue;
+        }
+
         /* The device pointed to by dev contains information about
            the hidraw device. In order to get information about the
            USB device, get the parent device with the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ include_directories("${TCAM_SOURCE_DIR}/src/gobject")
 
 link_libraries( dutils_img::base )
 
+add_subdirectory(unit)
 add_subdirectory(integration)
 
 find_package(GStreamer REQUIRED QUIET)

--- a/tests/integration/start_stop/start-stop.cpp
+++ b/tests/integration/start_stop/start-stop.cpp
@@ -74,18 +74,19 @@ int main(int argc, char* argv[])
     CLI::App app { "start-stop test" };
 
     std::string serial;
-    app.add_option("-s,--serial", serial, "Serial number of the file that shall be used.", false);
+    app.add_option("-s,--serial", serial, "Serial number of the file that shall be used.");
 
     std::string caps_str;
-    app.add_option("-c,--caps", caps_str, "GStreamer caps the device shall use.", false);
+    app.add_option("-c,--caps", caps_str, "GStreamer caps the device shall use.");
 
     GstState rest_state { GST_STATE_NULL };
 
     std::map<std::string, GstState> state_map { { "NULL", GST_STATE_NULL },
                                                 { "READY", GST_STATE_READY } };
 
-    app.add_option("-r,--rest", rest_state, "\"Stop\" state that shall be used", "NULL")
-        ->transform(CLI::CheckedTransformer(state_map, CLI::ignore_case));
+    app.add_option("-r,--rest", rest_state, "\"Stop\" state that shall be used")
+        ->transform(CLI::CheckedTransformer(state_map, CLI::ignore_case))
+        ->default_str("NULL");
 
     // allow --gst-debug etc
     app.allow_extras(true);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(uvc-extension-loader-check-test
+  uvc-extension-loader-check.cpp
+  )
+
+add_test(
+  NAME unit-uvc-extension-loader-check
+  COMMAND uvc-extension-loader-check-test
+  )

--- a/tests/unit/uvc-extension-loader-check.cpp
+++ b/tests/unit/uvc-extension-loader-check.cpp
@@ -1,0 +1,33 @@
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
+#define CATCH_CONFIG_MAIN
+#include <catch.hpp>
+
+#include "v4l2/uvc-extension-loader-check.h"
+
+TEST_CASE("metadata capture nodes are rejected from device_caps", "[uvc-extension-loader]")
+{
+    v4l2_capability caps = {};
+    caps.capabilities = V4L2_CAP_DEVICE_CAPS | V4L2_CAP_VIDEO_CAPTURE;
+    caps.device_caps = V4L2_CAP_META_CAPTURE;
+
+    REQUIRE(tcam::uvc::is_metadata_capture_device(caps));
+}
+
+TEST_CASE("metadata capture nodes are rejected from capabilities when device_caps is absent",
+          "[uvc-extension-loader]")
+{
+    v4l2_capability caps = {};
+    caps.capabilities = V4L2_CAP_META_CAPTURE | V4L2_CAP_VIDEO_CAPTURE;
+
+    REQUIRE(tcam::uvc::is_metadata_capture_device(caps));
+}
+
+TEST_CASE("device_caps take precedence over capabilities", "[uvc-extension-loader]")
+{
+    v4l2_capability caps = {};
+    caps.capabilities =
+        V4L2_CAP_DEVICE_CAPS | V4L2_CAP_META_CAPTURE | V4L2_CAP_VIDEO_CAPTURE;
+    caps.device_caps = V4L2_CAP_VIDEO_CAPTURE;
+
+    REQUIRE_FALSE(tcam::uvc::is_metadata_capture_device(caps));
+}

--- a/tools/tcam-capture/mainwindow.cpp
+++ b/tools/tcam-capture/mainwindow.cpp
@@ -47,7 +47,7 @@ namespace
 bool has_property (GstElement* element, const char* name)
 {
     return g_object_class_find_property(G_OBJECT_GET_CLASS(element), name) != nullptr;
-};
+}
 
 } // namespace
 

--- a/tools/tcam-capture/propertywidget.cpp
+++ b/tools/tcam-capture/propertywidget.cpp
@@ -365,6 +365,10 @@ void IntWidget::setup_ui()
         {
             scale = TcamSliderScale::Logarithmic;
         }
+        else
+        {
+            scale = TcamSliderScale::Linear;
+        }
 
         p_slider = new TcamSlider(scale);
     }

--- a/tools/tcam-uvc-extension-loader/main.cpp
+++ b/tools/tcam-uvc-extension-loader/main.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CLI11.hpp"
+#include "uvc-extension-loader-check.h"
 #include "uvc-extension-loader.h"
 
 #include <cstring>
@@ -23,16 +24,6 @@
 #include <sys/ioctl.h>
 #include <unistd.h> // close()
 #include <vector>
-
-
-static __u32 get_effective_caps(const v4l2_capability& caps)
-{
-    if (caps.capabilities & V4L2_CAP_DEVICE_CAPS)
-    {
-        return caps.device_caps;
-    }
-    return caps.capabilities;
-}
 
 
 int main(int argc, char** argv)
@@ -99,7 +90,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (get_effective_caps(caps) & V4L2_CAP_META_CAPTURE)
+    if (tcam::uvc::is_metadata_capture_device(caps))
     {
         printf("Refusing metadata capture device node \"%s\".\n", device.c_str());
         close(fd);

--- a/tools/tcam-uvc-extension-loader/main.cpp
+++ b/tools/tcam-uvc-extension-loader/main.cpp
@@ -19,8 +19,20 @@
 
 #include <cstring>
 #include <fcntl.h> // O_RDWR
+#include <linux/videodev2.h>
+#include <sys/ioctl.h>
 #include <unistd.h> // close()
 #include <vector>
+
+
+static __u32 get_effective_caps(const v4l2_capability& caps)
+{
+    if (caps.capabilities & V4L2_CAP_DEVICE_CAPS)
+    {
+        return caps.device_caps;
+    }
+    return caps.capabilities;
+}
 
 
 int main(int argc, char** argv)
@@ -74,6 +86,23 @@ int main(int argc, char** argv)
     if (fd == -1)
     {
         printf("Unable to open device \"%s\": %s\n", device.c_str(), strerror(errno));
+        return 1;
+    }
+
+    struct v4l2_capability caps = {};
+    if (ioctl(fd, VIDIOC_QUERYCAP, &caps) == -1)
+    {
+        printf("Unable to query device capabilities for \"%s\": %s\n",
+               device.c_str(),
+               strerror(errno));
+        close(fd);
+        return 1;
+    }
+
+    if (get_effective_caps(caps) & V4L2_CAP_META_CAPTURE)
+    {
+        printf("Refusing metadata capture device node \"%s\".\n", device.c_str());
+        close(fd);
         return 1;
     }
 


### PR DESCRIPTION
# Description

Restrict UVC extension loading and device enumeration to primary video
index 0 nodes so metadata siblings are ignored.

root cause: /dev/video1 is metadata-only with a 1024-byte payload buffer, and the
current rule still runs tcam-uvc-extension-loader on it. That matches the warning exactly. I
patched the udev rules so the loader only runs on ATTR{index}=="0" capture nodes
 
Fixes kernel: uvcvideo: Failed to query (GET_CUR) UVC control 1
on unit 3: -32 (exp. 1024) warnings.

# How Has This Been Tested?

Tested on our The Imaging Source Europe GmbH DMK 37BUX178.

# Is this pull request on the correct branch?

on the development branch, on top of another minor PR of mine.

